### PR TITLE
Basic docs and ci

### DIFF
--- a/.github/workflows/WCH_V307_RISC-V.yml
+++ b/.github/workflows/WCH_V307_RISC-V.yml
@@ -16,9 +16,11 @@ jobs:
           fetch-depth: '0'
       - name: update-tools
         run: |
-          sudo apt install gcc-riscv64-unknown-elf
+          wget --no-check-certificate https://static.dev.sifive.com/dev-tools/freedom-tools/v2020.12/riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14.tar.gz
+          tar -xvzf riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14.tar.gz
       - name: target-riscv64-unknown-elf
         run: |
+          PATH=./riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14/bin:$PATH
           bash ./Rebuild.sh
           ls -la ../Output/BareMetal_WCH_V307_RISC-V.hex
         working-directory: ./Build

--- a/.github/workflows/WCH_V307_RISC-V.yml
+++ b/.github/workflows/WCH_V307_RISC-V.yml
@@ -1,0 +1,24 @@
+﻿name: WCH_V307_RISC-V
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+jobs:
+  target-gcc-riscv64-unknown-elf:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+      - name: update-tools
+        run: |
+          sudo apt install gcc-riscv64-unknown-elf
+      - name: target-riscv64-unknown-elf
+        run: |
+          bash ./Rebuild.sh
+          ls -la ../Output/BareMetal_WCH_V307_RISC-V.hex
+        working-directory: ./Build

--- a/.github/workflows/WCH_V307_RISC-V.yml
+++ b/.github/workflows/WCH_V307_RISC-V.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           wget --no-check-certificate https://static.dev.sifive.com/dev-tools/freedom-tools/v2020.12/riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14.tar.gz
           tar -xvzf riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14.tar.gz
+        working-directory: ./Build
       - name: target-riscv64-unknown-elf
         run: |
           PATH=./riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14/bin:$PATH

--- a/.github/workflows/WCH_V307_RISC-V.yml
+++ b/.github/workflows/WCH_V307_RISC-V.yml
@@ -16,12 +16,12 @@ jobs:
           fetch-depth: '0'
       - name: update-tools
         run: |
-          wget --no-check-certificate https://static.dev.sifive.com/dev-tools/freedom-tools/v2020.12/riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14.tar.gz
-          tar -xvzf riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14.tar.gz
+          wget --no-check-certificate https://github.com/xpack-dev-tools/riscv-none-embed-gcc-xpack/releases/download/v10.2.0-1.2/xpack-riscv-none-embed-gcc-10.2.0-1.2-linux-x64.tar.gz
+          tar -xvzf xpack-riscv-none-embed-gcc-10.2.0-1.2-linux-x64.tar.gz
         working-directory: ./Build
       - name: target-riscv64-unknown-elf
         run: |
-          PATH=./riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14/bin:$PATH
+          PATH=./xpack-riscv-none-embed-gcc-10.2.0-1.2/bin:$PATH
           bash ./Rebuild.sh
           ls -la ../Output/BareMetal_WCH_V307_RISC-V.hex
         working-directory: ./Build

--- a/.github/workflows/WCH_V307_RISC-V.yml
+++ b/.github/workflows/WCH_V307_RISC-V.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   target-gcc-riscv64-unknown-elf:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash

--- a/Build/Makefile
+++ b/Build/Makefile
@@ -27,7 +27,7 @@ ERR_MSG_FORMATER_SCRIPT = ../Tools/Scripts/CompilerErrorFormater.py
 # Toolchain
 ############################################################################################
 
-TOOLCHAIN = riscv64-unknown-elf
+TOOLCHAIN = riscv-none-embed
 AS        = $(TOOLCHAIN)-g++
 CC        = $(TOOLCHAIN)-g++
 CPP       = $(TOOLCHAIN)-g++

--- a/Build/Makefile
+++ b/Build/Makefile
@@ -27,7 +27,7 @@ ERR_MSG_FORMATER_SCRIPT = ../Tools/Scripts/CompilerErrorFormater.py
 # Toolchain
 ############################################################################################
 
-TOOLCHAIN = riscv-none-embed
+TOOLCHAIN = riscv64-unknown-elf
 AS        = $(TOOLCHAIN)-g++
 CC        = $(TOOLCHAIN)-g++
 CPP       = $(TOOLCHAIN)-g++

--- a/Build/Rebuild.sh
+++ b/Build/Rebuild.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-make clean 
+make clean
 make all 2>&1 | tee ../Output/Build.log

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ interrupt handler.
 
 ## Building the Application
 
-Build on `*nix*` is easy using an installed `gcc-riscv64-unknown-elf`
+Build on `*nix*` is easy using an installed `gcc-riscv-none-embed`
 
-Both Make and Cmake can be used to build the Application:
+Make can be used to build the Application:
 
 ```sh
 cd WCH_V307_RISC-V
@@ -49,8 +49,8 @@ bash Rebuild.sh
 The build results including ELF-file, HEX-mask, MAP-file
 and assembly list file are created in the `Output` directory.
 
-If `gcc-riscv64-unknown-elf` is not installed, it can easily
-be obtained [here](https://github.com/sifive/freedom-tools/releases).
+If `gcc-riscv-none-embed` is not installed, it can easily
+be obtained [here](https://github.com/xpack-dev-tools/riscv-none-embed-gcc-xpack/releases).
 Add the path of the RISC-V GCC tools' bin folder to `$PATH`
 in the usual `*nix` way.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,61 @@
 # WCH_V307_RISC-V
 Bare metal programming on WCH RISC-V MCU CH32V307VCT6 board (CH32V307V-EVT-R1)
+
+[![Build Status](https://github.com/Embedded-System-Lovers/WCH_V307_RISC-V/actions/workflows/WCH_V307_RISC-V.yml/badge.svg)](https://github.com/Embedded-System-Lovers/WCH_V307_RISC-V/actions)
+
+This repository implements an entirely manually-written, pure
+_bare_ _metal_ Blinky Project for the SiFive
+RISC-V MCU CH32V307VCT6 board  (CH32V307V-EVT-R1).
+
+Features include:
+  - CPU, power, chip, clock and PLL initialization,
+  - timebase derived from `mtimer`,
+  - blinky LED show with adjustable frequency,
+  - implementation in C99 with absolute minimal use of assembly.
+
+A clear and easy-to-understand build system based on GNUmake
+completes this fun and educational project.
+
+This repository provides keen insight on starting up
+a _bare_ _metal_ SiFive RISC-V controller.
+
+## Details on the Application
+
+The application boots from a tiny startup code in the boot ROM.
+
+Following low-level chip initialization, the program jumps to
+the `main()` subroutine. Here the timer interrupt is setup
+for LED blinky.
+
+The adjustable LED-phase (its half-period) can be tuned
+to provide a rudimentary, visible blinky LED show.
+The timebase for blinky is based on the `mtimer`
+interrupt handler.
+
+## Building the Application
+
+Build on `*nix*` is easy using an installed `gcc-riscv64-unknown-elf`
+
+Both Make and Cmake can be used to build the Application:
+
+```sh
+cd WCH_V307_RISC-V
+cd Build
+```
+### Make
+```
+bash Rebuild.sh
+```
+The build results including ELF-file, HEX-mask, MAP-file
+and assembly list file are created in the `Output` directory.
+
+If `gcc-riscv64-unknown-elf` is not installed, it can easily
+be obtained [here](https://github.com/sifive/freedom-tools/releases).
+Add the path of the RISC-V GCC tools' bin folder to `$PATH`
+in the usual `*nix` way.
+
+## Continuous Integration
+
+CI runs on pushes and pull-requests with simple
+at the moment a single build including result verification
+runs on `ubuntu-latest` using GitHub Actions.


### PR DESCRIPTION
Hi Amine (@Chalandi) the purpose of this PR is to add basic docs and a CI job.

I noticed that you changed the `prefix` of the IRSC-V toolchain for this particular project and also added a dedicated `Build` directory.

Regarding the toolchain name, you need to tell me where to get this toolchain (i.e., via `wget`) in order to finish this PR. At the moment, I actually modified `Makefile` to use the Tooolchain that we had used for our previous example.

As a final note, I feel like both RISC projects should use the same build-tools and have the same `Build` directory as we move forward. But this is a detail we can handle later.

Cc: @gdobato and @sajtkukac 