### PR TITLE
Enable the floating point unit

### DIFF
--- a/.github/workflows/WCH_V307_RISC-V.yml
+++ b/.github/workflows/WCH_V307_RISC-V.yml
@@ -5,7 +5,7 @@ on:
       - '**'
   pull_request:
 jobs:
-  target-gcc-riscv64-unknown-elf:
+  target-gcc-riscv-none-embed:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -19,7 +19,7 @@ jobs:
           wget --no-check-certificate https://github.com/xpack-dev-tools/riscv-none-embed-gcc-xpack/releases/download/v10.2.0-1.2/xpack-riscv-none-embed-gcc-10.2.0-1.2-linux-x64.tar.gz
           tar -xvzf xpack-riscv-none-embed-gcc-10.2.0-1.2-linux-x64.tar.gz
         working-directory: ./Build
-      - name: target-riscv64-unknown-elf
+      - name: target-riscv-none-embed
         run: |
           PATH=./xpack-riscv-none-embed-gcc-10.2.0-1.2/bin:$PATH
           bash ./Rebuild.sh

--- a/Build/Makefile
+++ b/Build/Makefile
@@ -100,7 +100,8 @@ CPPOPS  = $(OPT)                                        \
           -fno-threadsafe-statics                       \
           -fno-enforce-eh-specs                         \
           -ftemplate-depth=128                          \
-          -Wzero-as-null-pointer-constant
+          -Wzero-as-null-pointer-constant               \
+          -fsingle-precision-constant
 
 ############################################################################################
 # Assembler flags

--- a/Build/Makefile
+++ b/Build/Makefile
@@ -60,7 +60,7 @@ VERBOSE_GCC = -frecord-gcc-switches -fverbose-asm
 # Target's Compiler flags
 ############################################################################################
 
-ARCH = -march=rv32i -mabi=ilp32 -msmall-data-limit=0 -falign-functions=4
+ARCH = -march=rv32imafc -mabi=ilp32f -msmall-data-limit=0 -falign-functions=4
 
 ############################################################################################
 # C Compiler flags
@@ -77,7 +77,7 @@ COPS  = $(OPT)                                        \
         -Wextra                                       \
         -fomit-frame-pointer                          \
         -gdwarf-2                                     \
-        -fno-exceptions
+        -fsingle-precision-constant
 
 ############################################################################################
 # C++ Compiler flags
@@ -107,8 +107,7 @@ CPPOPS  = $(OPT)                                        \
 ############################################################################################
 
 ifeq ($(AS), $(TOOLCHAIN)-as)
-ASOPS =  -march=rv32i          \
-         -alh 
+ASOPS =  -march=rv32imafc -alh
 else
 ASOPS = $(OPT)                                        \
         $(ARCH)                                       \
@@ -157,9 +156,10 @@ endif
 ############################################################################################
 # Source Files
 ############################################################################################
-SRC_FILES := $(SRC_DIR)/Appli/main.c      \
-             $(SRC_DIR)/Startup/boot.s    \
-             $(SRC_DIR)/Startup/intvect.c \
+SRC_FILES := $(SRC_DIR)/Appli/main.c         \
+             $(SRC_DIR)/Appli/DummyClass.cpp \
+             $(SRC_DIR)/Startup/boot.s       \
+             $(SRC_DIR)/Startup/intvect.c    \
              $(SRC_DIR)/Startup/Startup.c
 
 ############################################################################################

--- a/Code/Appli/DummyClass.cpp
+++ b/Code/Appli/DummyClass.cpp
@@ -1,0 +1,8 @@
+#include"DummyClass.h"
+
+const DummyClass global_DummyClass(2, 3);
+
+extern "C" int dummy_cpptest()
+{
+    return global_DummyClass.mul();
+}

--- a/Code/Appli/DummyClass.h
+++ b/Code/Appli/DummyClass.h
@@ -1,0 +1,28 @@
+#ifndef _DUMMYCLASS_H_
+#define _DUMMYCLASS_H_
+
+
+#ifdef __cplusplus
+
+class DummyClass
+{
+  public:
+    DummyClass(const int w = 0,
+               const int h = 0) : a(w),
+                                  b(h) { }
+
+    ~DummyClass() { }
+
+    int mul(void) const
+    {
+      return a * b;
+    }
+
+private:
+  int a;
+  int b;
+};
+
+#endif
+
+#endif

--- a/Code/Appli/main.c
+++ b/Code/Appli/main.c
@@ -2,7 +2,17 @@
 #include "Platform_Types.h"
 #include "CH32V30xxx.h" 
 
+
+int dummy_cpptest(void);
+
+float val=33.14;
+volatile int t = 1;
+
+
 int main(void)
 {
-    for(;;);
+  t = dummy_cpptest();
+  val = ((float)t/2 + 11.12) * 2;
+
+  for(;;);
 }

--- a/Code/Memory_Map.ld
+++ b/Code/Memory_Map.ld
@@ -53,7 +53,7 @@ SECTIONS
   .boot : ALIGN(4)
   {
     PROVIDE(__BOOT_BASE_ADDRESS = .);
-    *boot.o(.text)
+    *boot.o(.text*)
     . = ALIGN(4);
   } > FLASH
   
@@ -61,7 +61,7 @@ SECTIONS
   .text : ALIGN(4)
   {
     PROVIDE(__CODE_BASE_ADDRESS = .);
-    *(.text)
+    *(.text*)
     . = ALIGN(4);
   } > FLASH
 
@@ -77,7 +77,7 @@ SECTIONS
   .rodata : ALIGN(4)
   {
     PROVIDE(__RODATA_BASE_ADDRESS = .);
-    *(.rodata)
+    *(.rodata*)
     . = ALIGN(4);
   } > FLASH
 
@@ -86,9 +86,9 @@ SECTIONS
   {
     __CTOR_LIST__ = . ;
     KEEP (*(SORT(.ctors.*)))
-    KEEP (*(.ctors))
+    KEEP (*(.ctors*))
     KEEP (*(SORT(.init_array.*)))
-    KEEP (*(.init_array))
+    KEEP (*(.init_array*))
     LONG(-1) ;
     __CTOR_END__ = . ;
   }  > FLASH
@@ -99,9 +99,9 @@ SECTIONS
   {
     __DTOR_LIST__ = . ;
     KEEP (*(SORT(.dtors.*)))
-    KEEP (*(.dtors))
+    KEEP (*(.dtors*))
     KEEP (*(SORT(.fini_array.*)))
-    KEEP (*(.fini_array))
+    KEEP (*(.fini_array*))
     LONG(-1) ;
     __DTOR_END__ = . ;
   } > FLASH
@@ -127,26 +127,26 @@ SECTIONS
   /* The FLASH-to-RAM initialized data sections */
   .data : ALIGN(4) 
   {
-    *(.data)
+    *(.data*)
     . = ALIGN(4);
   } > RAM  AT>FLASH
   
   .sdata : ALIGN(4) 
   {
-    *(.sdata)
+    *(.sdata*)
     . = ALIGN(4);
   } > RAM  AT>FLASH
 
   /* The uninitialized (zero-cleared) data sections */
   .bss : ALIGN(4)
   {
-    *(.bss)
+    *(.bss*)
     . = ALIGN(4);
   } > RAM
   
   .sbss : ALIGN(4)
   {
-    *(.sbss)
+    *(.sbss*)
     . = ALIGN(4);
   } > RAM
 

--- a/Code/Startup/boot.s
+++ b/Code/Startup/boot.s
@@ -18,11 +18,11 @@
 .file "boot.s"
 
 /*******************************************************************************************
-  \brief  
+  \brief  entry point
   
-  \param  
+  \param  void
   
-  \return 
+  \return void
 ********************************************************************************************/
 .section .text
 .type _start, @function
@@ -32,8 +32,9 @@
 .globl _start
 
 _start:
-        /* disable all interrupts flag */
-        csrw mstatus, x0
+        /* disable all interrupts and enable the FPU */
+        li x1, 0x2000
+        csrw mstatus, x1
 
         /* disable all specific interrupt sources */
         csrw mie, x0
@@ -41,7 +42,7 @@ _start:
         /* setup the stack pointer */
         la sp, __STACK_TOP
 
-
+        /* jump to the C runtime initialization */
         j Startup_Init
 
 .size _start, .-_start


### PR DESCRIPTION
Hi Chris (@ckormanyos),

In this pull-request the FPU is enabled and the compiler flags is set accordingly to support the target RISC-V extension.

According to the `Hardware instruction set register (misa)` the ISA is `rv32imafcxw` :

![image](https://user-images.githubusercontent.com/7204744/213891155-2aa33343-4809-4f6a-b61b-4928a3a6fef5.png)

but the toolchain issue an error when I use `-march=rv32imafcxw`: 
Error: x ISA extension `xw' must be set with the versions

As I don't have this information, I just used `-march=rv32imafc`.

I tested the FPU on the debugger it gave the expected result, I committed the test code in main() as example we can delete it later together with the dummy C++ class that I added just to verify that ctor initialization is working. 

@gdobato @sajtkukac 